### PR TITLE
商品一覧表示機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,8 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create]
 
   def index
-    @items = Item.includes(:user).order("created_at DESC")
-
+    @items = Item.includes(:user).order('created_at DESC')
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,6 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create]
 
   def index
+    @items = Item.includes(:user).order("created_at DESC")
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,6 +3,7 @@ class ItemsController < ApplicationController
 
   def index
     @items = Item.includes(:user).order("created_at DESC")
+
   end
 
   def new

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -14,7 +14,7 @@ class Item < ApplicationRecord
     validates :name
     validates :description
     validates :price,         inclusion: { in: 300..9_999_999, message: 'is out of setting range' },
-                              numericality: {only_integer: true,  message: 'is invalid. Please input half-width numbers only' }
+                              numericality: { only_integer: true, message: 'is invalid. Please input half-width numbers only' }
   end
 
   with_options numericality: { other_than: 1, message: "can't be blank" } do

--- a/app/models/shipping_payment.rb
+++ b/app/models/shipping_payment.rb
@@ -2,7 +2,7 @@ class ShippingPayment < ActiveHash::Base
   self.data = [
     { id: 1, name: '---' },
     { id: 2, name: '着払い(購入者負担)' },
-    { id: 3, name: '送料込み(出品者負担)(購入者負担)' }
+    { id: 3, name: '送料込み(出品者負担)' }
 
   ]
 

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,6 +128,7 @@
     </div>
     <ul class='item-lists'>
 
+<%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 <% unless @items.length == 0 %>
   <% @items.each do |item| %>
     <li class='list'>
@@ -150,8 +151,13 @@
       </div>
     </li>
   <% end %>
-<% else %>
-    <li class='list'>
+          <%# 商品が売れていればsold outを表示しましょう %>
+          <div class='sold-out'>
+            <span>Sold Out!!</span>
+          </div>
+          <%# //商品が売れていればsold outを表示しましょう %>
+      <% else %>
+        <li class='list'>
           <%= link_to '#' do %>
             <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
             <div class='item-info'>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,7 +128,6 @@
     </div>
     <ul class='item-lists'>
 
-<%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 <% unless @items.length == 0 %>
   <% @items.each do |item| %>
     <li class='list'>
@@ -151,41 +150,8 @@
       </div>
     </li>
   <% end %>
-
-    <%# 以下、商品が売れていればsold outを表示する機能を購入機能実装後に追記するため、その時のために残しておく %>
-      <div class='item-info'>
-        <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
-          <%# 商品が売れていればsold outを表示しましょう %>
-          <%# この機能は商品購入機能実装時に追加する%>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= "商品名" %>
-          </h3>
-          <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
-            </div>
-          </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //以下、商品が売れていればsold outを表示する機能を購入機能実装後に追記するため、その時のために残しておく %>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
-      <% else %>
-        <li class='list'>
+<% else %>
+    <li class='list'>
           <%= link_to '#' do %>
             <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
             <div class='item-info'>
@@ -203,8 +169,6 @@
           <% end %>
         </li>
       <% end %>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -131,23 +131,35 @@
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
   <% @items.each do |item| %>
-    <div class="content_post" style="background-image: url(<%= item.image %>);">
-    
-    <%= image_tag(item.image.variant(resize: '300x300'), class: :card__img )%>
-      <p><%= item.name %></p>
-      <span class="name">
-        <%= item.price %>
-      </span>
-    </div>
+    <li class='list'>
+      <%= link_to "#" do %>
+        <div class="item-img-content" style="background-image: url(<%= item.image %>);">
+          <%= image_tag(item.image, class: "item-img" )%>
+            <div class='item-info'>
+              <h3 class='item-name'>
+                <%= item.name %>
+              </h3>
+            <div class='item-price'>
+              <span><%= item.price %>円<br><%= item.shipping_payment.name %></span>
+                <div class='star-btn'>
+                  <%= image_tag "star.png", class:"star-icon" %>
+                  <span class='star-count'>0</span>
+                </div>
+            </div>
+          </div> 
+      <% end %>
+      </div>
+    </li>
   <% end %>
 
-
+      <div class='item-info'>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
           <%= image_tag "item-sample.png", class: "item-img" %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
+          <%# この機能は商品購入機能実装時に追加する%>
           <div class='sold-out'>
             <span>Sold Out!!</span>
           </div>
@@ -172,6 +184,7 @@
 
       <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
       <%# 商品がある場合は表示されないようにしましょう %>
+      <% if @items.length == 0 %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -189,6 +202,7 @@
         </div>
         <% end %>
       </li>
+      <% end %>
       <%# //商品がある場合は表示されないようにしましょう %>
       <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
     </ul>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -129,6 +129,19 @@
     <ul class='item-lists'>
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+
+  <% @items.each do |item| %>
+    <div class="content_post" style="background-image: url(<%= item.image %>);">
+    
+    <%= image_tag(item.image.variant(resize: '300x300'), class: :card__img )%>
+      <p><%= item.name %></p>
+      <span class="name">
+        <%= item.price %>
+      </span>
+    </div>
+  <% end %>
+
+
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,8 +128,8 @@
     </div>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
+<%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+<% unless @items.length == 0 %>
   <% @items.each do |item| %>
     <li class='list'>
       <%= link_to "#" do %>
@@ -152,19 +152,18 @@
     </li>
   <% end %>
 
+    <%# 以下、商品が売れていればsold outを表示する機能を購入機能実装後に追記するため、その時のために残しておく %>
       <div class='item-info'>
-      <li class='list'>
+        <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
           <%= image_tag "item-sample.png", class: "item-img" %>
-
           <%# 商品が売れていればsold outを表示しましょう %>
           <%# この機能は商品購入機能実装時に追加する%>
           <div class='sold-out'>
             <span>Sold Out!!</span>
           </div>
           <%# //商品が売れていればsold outを表示しましょう %>
-
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
@@ -180,28 +179,29 @@
         </div>
         <% end %>
       </li>
+      <%# //以下、商品が売れていればsold outを表示する機能を購入機能実装後に追記するため、その時のために残しておく %>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
       <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
       <%# 商品がある場合は表示されないようにしましょう %>
-      <% if @items.length == 0 %>
-      <li class='list'>
-        <%= link_to '#' do %>
-        <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            商品を出品してね！
-          </h3>
-          <div class='item-price'>
-            <span>99999999円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
+      <% else %>
+        <li class='list'>
+          <%= link_to '#' do %>
+            <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
+            <div class='item-info'>
+              <h3 class='item-name'>
+                商品を出品してね！
+              </h3>
+              <div class='item-price'>
+                <span>99999999円<br>(税込み)</span>
+                  <div class='star-btn'>
+                    <%= image_tag "star.png", class:"star-icon" %>
+                    <span class='star-count'>0</span>
+                  </div>
+              </div>
             </div>
-          </div>
-        </div>
-        <% end %>
-      </li>
+          <% end %>
+        </li>
       <% end %>
       <%# //商品がある場合は表示されないようにしましょう %>
       <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,7 +128,6 @@
     </div>
     <ul class='item-lists'>
 
-<%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 <% unless @items.length == 0 %>
   <% @items.each do |item| %>
     <li class='list'>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -134,10 +134,16 @@
       <%= link_to "#" do %>
         <div class="item-img-content" style="background-image: url(<%= item.image %>);">
           <%= image_tag(item.image, class: "item-img" )%>
-            <div class='item-info'>
-              <h3 class='item-name'>
-                <%= item.name %>
-              </h3>
+            <%# 商品が売れていればsold outを表示しましょう %>
+            <div class='sold-out'>
+            <span>Sold Out!!</span>
+            </div>
+            <%# //商品が売れていればsold outを表示しましょう %>
+        </div>
+        <div class='item-info'>
+          <h3 class='item-name'>
+            <%= item.name %>
+          </h3>
             <div class='item-price'>
               <span><%= item.price %>円<br><%= item.shipping_payment.name %></span>
                 <div class='star-btn'>
@@ -147,14 +153,8 @@
             </div>
           </div> 
       <% end %>
-      </div>
     </li>
   <% end %>
-          <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
       <% else %>
         <li class='list'>
           <%= link_to '#' do %>

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :item do
     name { '自作パソコン' }
     description { '自作パソコンです。CPUはIntelの第１０世代Corei5-10500で最大で4.5Ghzのクロック周波数です。メモリは16GB、グラボはGTX1650、M.2のSSD 1TBを搭載してます。' }
-    price { 50000 }
+    price { 50_000 }
     category_id { 8 }
     condition_id { 4 }
     shipping_payment_id { 2 }

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Item, type: :model do
       end
 
       it '価格(price)が10,000,000以上と出品できない' do
-        @item.price = 10000000
+        @item.price = 10_000_000
         @item.valid?
         expect(@item.errors.full_messages).to include('Price is out of setting range')
       end
@@ -118,9 +118,8 @@ RSpec.describe Item, type: :model do
       it 'ユーザー情報がないと出品できない' do
         @item.user = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("User must exist")
+        expect(@item.errors.full_messages).to include('User must exist')
       end
-
     end
   end
 end


### PR DESCRIPTION
# What
商品一覧機能をトップページに追加した。

# Why
トップページに出品された商品を表示することで
より商品が見やすく、詳細ページを見なくても価格や配送料の負担の有無がわかり使いやすくするため。

Soludout表示機能は購入機能実装後に追加しますが
元からついている画像については残してあります。ご指摘あればこちらは削除いたします。

# Gyazo
出品商品がある場合にダミーが表示されず、かつ出品の商品が
新しい順に左上から表示される動画
https://gyazo.com/0a55fce872ddbd572f2e4253710feec8

出品商品がない場合にダミー商品が表示される動画
https://gyazo.com/474c271f1978c806aa68e25c7cc76335
